### PR TITLE
Fix hack to call spacy wrt its version

### DIFF
--- a/ewiser/spacy/disambiguate.py
+++ b/ewiser/spacy/disambiguate.py
@@ -334,7 +334,7 @@ if __name__ == '__main__':
 
     wsd = Disambiguator(args.checkpoint, lang=args.lang)
     nlp = load(args.spacy or args.lang, disable=['parser', 'ner'])
-    enable_wd(nlp, "wsd", wsd)
+    wsd.enable(nlp, "wsd")
 
     print('Input a sentence then press Enter:')
     while True:


### PR DESCRIPTION
The former hack to interact with different Spacy version (see https://github.com/cgravier/ewiser/blob/master/ewiser/spacy/disambiguate.py#L311)
was not properly called (instead a call to an unknown fucntion was made resulting in the program being unable to run for command-line inference).

Related to issues #4 and #5